### PR TITLE
livefs_edit/actions.py: add-packages-to-pool uses the base layer

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -534,9 +534,19 @@ def download_missing_pool_debs(ctxt, cache):
 @register_action()
 def add_packages_to_pool(ctxt, packages: List[str]):
     from apt.progress.text import AcquireProgress
-    fs = ctxt.mount_squash(get_squash_names(ctxt)[0])
-    overlay = ctxt.add_overlay(fs, ctxt.tmpdir())
-    cache = cache_for_dir(ctxt, overlay.p())
+
+    name = get_squash_names(ctxt)[0]
+    reltarget = f'new/{name}'
+    target = ctxt.p(reltarget)
+    if os.path.exists(target):
+        dir = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
+    else:
+        fs = ctxt.mount_squash(get_squash_names(ctxt)[0])
+        overlay = ctxt.add_overlay(fs, ctxt.tmpdir())
+        dir = overlay.p()
+
+    cache = cache_for_dir(ctxt, dir)
+
     with ctxt.logged(
             '** updating apt lists... **',
             '** updating apt lists done **'):


### PR DESCRIPTION
if it is already mounted. This way, if repositories were added to the sources list, packages from them can be added to the ISO